### PR TITLE
Add ntp_disable_monitor toggle

### DIFF
--- a/templates/ntp.conf.default.j2
+++ b/templates/ntp.conf.default.j2
@@ -24,3 +24,11 @@ statistics {{ ntp_conf_statistics|join(' ') }}
 filegen {{ item }} file {{ item }} type day enable
 {% endfor %}
 {% endif %}
+
+{% if ntp_disable_monitor %}
+# Disable the monitoring facility to prevent amplification attacks using ntpdc
+# monlist command when default restrict does not include the noquery flag. See
+# CVE-2013-5211 for more details.
+# Note: Monitoring will not be disabled with the limited restriction flag.
+disable monitor
+{% endif %}

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,3 +8,4 @@ ntp_service: ntpd
 ntp_file_conf: /etc/ntp.conf
 ntp_file_drift: /var/lib/ntp/ntp.drift
 ntp_dir_stats: /var/log/ntpstats
+ntp_disable_monitor: true


### PR DESCRIPTION
default ntp.conf for rhel6 comes with workaround for CVE-2013-5211
